### PR TITLE
Store/Update Product Slugs

### DIFF
--- a/src/Database/Factories/MagentoProductFactory.php
+++ b/src/Database/Factories/MagentoProductFactory.php
@@ -14,5 +14,6 @@ $factory->define(MagentoProduct::class, function (Faker $faker) {
         'status'     => 1,
         'visibility' => 1,
         'type'       => 'simple',
+        'slug'       => $faker->slug,
     ];
 });

--- a/src/Database/Migrations/2020_08_10_134125_add_slug_to_magento_products.php
+++ b/src/Database/Migrations/2020_08_10_134125_add_slug_to_magento_products.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSlugToMagentoProducts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('magento_products', function (Blueprint $table) {
+            $table->string('slug')->nullable()->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('magento_products', function (Blueprint $table) {
+            $table->removeColumn('slug');
+        });
+    }
+}

--- a/src/Support/MagentoProducts.php
+++ b/src/Support/MagentoProducts.php
@@ -107,6 +107,12 @@ class MagentoProducts extends PaginatableMagentoService
                 $this->syncProductCategories($attribute['value'], $product);
             }
 
+            if ($attribute['attribute_code'] === 'url_key') {
+                $product->update([
+                    'slug' => $attribute['value'],
+                ]);
+            }
+
             if ($this->isImageType($attribute['attribute_code'])) {
                 $this->downloadImage($attribute['value']);
             }

--- a/tests/Support/MagentoProductsTest.php
+++ b/tests/Support/MagentoProductsTest.php
@@ -181,4 +181,41 @@ class MagentoProductsTest extends TestCase
         Queue::assertPushed(fn (DownloadMagentoProductImage $downloadJob) => $downloadJob->directory === '/pub/media/catalog/product');
         Queue::assertPushed(fn (DownloadMagentoProductImage $downloadJob) => $downloadJob->fullUrl === '/pub/media/catalog/product/foo.jpg');
     }
+
+    public function test_magento_product_applies_slug_from_url_key()
+    {
+        $category = factory(MagentoCategory::class)->create();
+
+        $products = [
+            [
+                'id'         => '1',
+                'name'       => 'Dunder Mifflin Paper',
+                'sku'        => 'DFPC001',
+                'price'      => 19.99,
+                'status'     => '1',
+                'visibility' => '1',
+                'type_id'    => 'simple',
+                'created_at' => now(),
+                'updated_at' => now(),
+                'weight'     => 10.00,
+                'extension_attributes' => [
+                    'website_id' => [1],
+                ],
+                'custom_attributes' => [
+                    [
+                        'attribute_code' => 'url_key',
+                        'value'          => 'dunder-mifflin-paper',
+                    ],
+                ],
+            ],
+        ];
+
+        $magentoProducts = new MagentoProducts();
+
+        $magentoProducts->updateProducts($products);
+
+        $product = MagentoProduct::first();
+        $this->assertNotNull($product);
+        $this->assertEquals('dunder-mifflin-paper', $product->slug);
+    }
 }


### PR DESCRIPTION
PR adds the ability to store product slugs from the API to the Magento Products table for quick and easy usage.

Before, we would have to dive into the custom attributes to resolve the URL key. This makes it quickly available from the top-level model.