### PR TITLE
Product attribute groups performance improvements

### DIFF
--- a/src/Jobs/UpdateProductAttributeGroup.php
+++ b/src/Jobs/UpdateProductAttributeGroup.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Grayloon\Magento\Jobs;
+
+use Grayloon\Magento\Magento;
+use Grayloon\Magento\Models\MagentoCustomAttributeType;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateProductAttributeGroup implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The Magento Custom Attribute Type.
+     *
+     * @var \Grayloon\Magento\Models\MagentoCustomAttributeType
+     */
+    public $type;
+    
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(MagentoCustomAttributeType $type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $api = (new Magento())->api('productAttributes')
+            ->show($this->type->name)
+            ->json();
+
+        $this->type->update([
+            'display_name' => $api['default_frontend_label'] ?? $this->type->display_name,
+            'options'      => $api['options'] ?? [],
+        ]);
+    }
+}

--- a/src/Support/HasCustomAttributes.php
+++ b/src/Support/HasCustomAttributes.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Grayloon\Magento\Support;
+
+use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
+use Grayloon\Magento\Models\MagentoCustomAttributeType;
+use Illuminate\Support\Str;
+
+trait HasCustomAttributes
+{
+    /**
+     * Resolve the Custom Attribute Type by the Attribute Code.
+     *
+     * @param  string  $attributeCode
+     * @return \Grayloon\Magento\Models\MagentoCustomAttributeType
+     */
+    protected function resolveCustomAttributeType($attributeCode)
+    {
+        $type = MagentoCustomAttributeType::firstOrCreate(['name' => $attributeCode], [
+            'display_name' => Str::title(Str::snake(Str::studly($attributeCode), ' ')),
+            'options'      => [],
+        ]);
+
+        if ($type->wasRecentlyCreated) {
+            UpdateProductAttributeGroup::dispatch($type);
+        }
+
+        return $type;
+    }
+
+    /**
+     * Resolve the Custom Attribute Value by the provided options.
+     *
+     * @param  \Grayloon\Magento\Models\MagentoCustomAttributeType  $type
+     * @param  string  $value;
+     * @return string|null
+     */
+    protected function resolveCustomAttributeValue($type, $value)
+    {
+        if ($type->options) {
+            foreach ($type->options as $option) {
+                if ($option['value'] == $value) {
+                    return $option['label'];
+                }
+            }
+        }
+
+        if (is_array($value)) {
+            $value = json_encode($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Support/MagentoCategories.php
+++ b/src/Support/MagentoCategories.php
@@ -4,7 +4,6 @@ namespace Grayloon\Magento\Support;
 
 use Grayloon\Magento\Magento;
 use Grayloon\Magento\Models\MagentoCategory;
-use Grayloon\Magento\Models\MagentoCustomAttributeType;
 
 class MagentoCategories extends PaginatableMagentoService
 {

--- a/src/Support/MagentoCategories.php
+++ b/src/Support/MagentoCategories.php
@@ -8,6 +8,8 @@ use Grayloon\Magento\Models\MagentoCustomAttributeType;
 
 class MagentoCategories extends PaginatableMagentoService
 {
+    use HasCustomAttributes;
+    
     /**
      * The amount of total categories.
      *
@@ -107,55 +109,5 @@ class MagentoCategories extends PaginatableMagentoService
         }
 
         return $this;
-    }
-
-    /**
-     * Resolve the Custom Attribute Type by the Attribute Code.
-     *
-     * @param  string  $attributeCode
-     * @return \Grayloon\Magento\Models\MagentoCustomAttributeType
-     */
-    protected function resolveCustomAttributeType($attributeCode)
-    {
-        $type = MagentoCustomAttributeType::where('name', $attributeCode)
-            ->first();
-
-        if (! $type) {
-            $api = (new Magento())->api('productAttributes')
-                ->show($attributeCode)
-                ->json();
-
-            $type = MagentoCustomAttributeType::create([
-                'name'         => $attributeCode,
-                'display_name' => $api['default_frontend_label'] ?? $attributeCode,
-                'options'      => $api['options'] ?? [],
-            ]);
-        }
-
-        return $type;
-    }
-
-    /**
-     * Resolve the Custom Attribute Value by the provided options.
-     *
-     * @param  \Grayloon\Magento\Models\MagentoCustomAttributeType  $type
-     * @param  string  $value;
-     * @return string|null
-     */
-    protected function resolveCustomAttributeValue($type, $value)
-    {
-        if ($type->options) {
-            foreach ($type->options as $option) {
-                if ($option['value'] == $value) {
-                    return $option['label'];
-                }
-            }
-        }
-
-        if (is_array($value)) {
-            $value = json_encode($value);
-        }
-
-        return $value;
     }
 }

--- a/src/Support/MagentoCustomers.php
+++ b/src/Support/MagentoCustomers.php
@@ -8,6 +8,8 @@ use Grayloon\Magento\Models\MagentoCustomer;
 
 class MagentoCustomers extends PaginatableMagentoService
 {
+    use HasCustomAttributes;
+    
     /**
      * The amount of total customers.
      *
@@ -95,56 +97,6 @@ class MagentoCustomers extends PaginatableMagentoService
         }
 
         return $this;
-    }
-
-    /**
-     * Resolve the Custom Attribute Type by the Attribute Code.
-     *
-     * @param  string  $attributeCode
-     * @return \Grayloon\Magento\Models\MagentoCustomAttributeType
-     */
-    protected function resolveCustomAttributeType($attributeCode)
-    {
-        $type = MagentoCustomAttributeType::where('name', $attributeCode)
-            ->first();
-
-        if (! $type) {
-            $api = (new Magento())->api('productAttributes')
-                ->show($attributeCode)
-                ->json();
-
-            $type = MagentoCustomAttributeType::create([
-                'name'         => $attributeCode,
-                'display_name' => $api['default_frontend_label'] ?? $attributeCode,
-                'options'      => $api['options'] ?? [],
-            ]);
-        }
-
-        return $type;
-    }
-
-    /**
-     * Resolve the Custom Attribute Value by the provided options.
-     *
-     * @param  \Grayloon\Magento\Models\MagentoCustomAttributeType  $type
-     * @param  string  $value;
-     * @return string|null
-     */
-    protected function resolveCustomAttributeValue($type, $value)
-    {
-        if ($type->options) {
-            foreach ($type->options as $option) {
-                if ($option['value'] == $value) {
-                    return $option['label'];
-                }
-            }
-        }
-
-        if (is_array($value)) {
-            $value = json_encode($value);
-        }
-
-        return $value;
     }
 
     /**

--- a/src/Support/MagentoCustomers.php
+++ b/src/Support/MagentoCustomers.php
@@ -3,7 +3,6 @@
 namespace Grayloon\Magento\Support;
 
 use Grayloon\Magento\Magento;
-use Grayloon\Magento\Models\MagentoCustomAttributeType;
 use Grayloon\Magento\Models\MagentoCustomer;
 
 class MagentoCustomers extends PaginatableMagentoService

--- a/src/Support/MagentoProducts.php
+++ b/src/Support/MagentoProducts.php
@@ -4,7 +4,6 @@ namespace Grayloon\Magento\Support;
 
 use Grayloon\Magento\Jobs\DownloadMagentoProductImage;
 use Grayloon\Magento\Magento;
-use Grayloon\Magento\Models\MagentoCustomAttributeType;
 use Grayloon\Magento\Models\MagentoExtensionAttribute;
 use Grayloon\Magento\Models\MagentoExtensionAttributeType;
 use Grayloon\Magento\Models\MagentoProduct;
@@ -12,6 +11,8 @@ use Grayloon\Magento\Models\MagentoProductCategory;
 
 class MagentoProducts extends PaginatableMagentoService
 {
+    use HasCustomAttributes;
+    
     /**
      * The amount of total products.
      *
@@ -198,55 +199,5 @@ class MagentoProducts extends PaginatableMagentoService
         }
 
         return $this;
-    }
-
-    /**
-     * Resolve the Custom Attribute Type by the Attribute Code.
-     *
-     * @param  string  $attributeCode
-     * @return \Grayloon\Magento\Models\MagentoCustomAttributeType
-     */
-    protected function resolveCustomAttributeType($attributeCode)
-    {
-        $type = MagentoCustomAttributeType::where('name', $attributeCode)
-            ->first();
-
-        if (! $type) {
-            $api = (new Magento())->api('productAttributes')
-                ->show($attributeCode)
-                ->json();
-
-            $type = MagentoCustomAttributeType::create([
-                'name'         => $attributeCode,
-                'display_name' => $api['default_frontend_label'] ?? $attributeCode,
-                'options'      => $api['options'] ?? [],
-            ]);
-        }
-
-        return $type;
-    }
-
-    /**
-     * Resolve the Custom Attribute Value by the provided options.
-     *
-     * @param  \Grayloon\Magento\Models\MagentoCustomAttributeType  $type
-     * @param  string  $value;
-     * @return string|null
-     */
-    protected function resolveCustomAttributeValue($type, $value)
-    {
-        if ($type->options) {
-            foreach ($type->options as $option) {
-                if ($option['value'] == $value) {
-                    return $option['label'];
-                }
-            }
-        }
-
-        if (is_array($value)) {
-            $value = json_encode($value);
-        }
-
-        return $value;
     }
 }

--- a/tests/Support/HasCustomAttributesTest.php
+++ b/tests/Support/HasCustomAttributesTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Grayloon\Magento\Tests\Support;
+
+use Grayloon\Magento\Tests\TestCase;
+use Illuminate\Support\Facades\Queue;
+use Grayloon\Magento\Support\HasCustomAttributes;
+use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
+use Grayloon\Magento\Models\MagentoCustomAttributeType;
+
+class HasCustomAttributesTest extends TestCase
+{
+    public function test_resolves_new_custom_attribute_type()
+    {
+        Queue::fake();
+        
+        $newType = (new FakeSupportingClass)->exposedResolveCustomAttributeType('foo_bar');
+
+        $this->assertNotEmpty($newType);
+        $this->assertEquals('foo_bar', $newType->name);
+        $this->assertEquals('Foo Bar', $newType->display_name);
+        $this->assertIsArray($newType->options);
+        $this->assertEmpty($newType->options);
+        Queue::assertPushed(UpdateProductAttributeGroup::class, fn ($job) => $job->type->id === $newType->id);
+    }
+
+    public function test_resolves_existing_custom_attribute_type()
+    {
+        Queue::fake();
+        $existing = factory(MagentoCustomAttributeType::class)->create([
+            'name' => 'foo_bar',
+        ]);
+        
+        $type = (new FakeSupportingClass)->exposedResolveCustomAttributeType('foo_bar');
+
+        $this->assertNotEmpty($type);
+        $this->assertEquals($type->id, $existing->id);
+        $this->assertEquals(1, MagentoCustomAttributeType::count());
+        Queue::assertNothingPushed();
+    }
+
+    public function test_resolves_existing_raw_value_from_empty_options()
+    {
+        $type = factory(MagentoCustomAttributeType::class)->create([
+            'name' => 'foo_bar',
+        ]);
+        
+        $value = (new FakeSupportingClass)->exposedResolveCustomAttributeValue($type, 'foo');
+
+        $this->assertEquals('foo', $value);
+    }
+
+    public function test_resolves_correct_value_from_provided_options()
+    {
+        $type = factory(MagentoCustomAttributeType::class)->create([
+            'name' => 'foo_bar',
+            'options' => [
+                [
+                    'label' => 'New York',
+                    'value' => '1',
+                ],
+                [
+                    'label' => 'Los Angeles',
+                    'value' => '2',
+                ],
+            ],
+        ]);
+        
+        $value = (new FakeSupportingClass)->exposedResolveCustomAttributeValue($type, '1');
+
+        $this->assertEquals('New York', $value);
+    }
+
+    public function test_resolves_raw_value_from_option_not_supplied_in_options()
+    {
+        $type = factory(MagentoCustomAttributeType::class)->create([
+            'name' => 'foo_bar',
+            'options' => [
+                [
+                    'label' => 'New York',
+                    'value' => '1',
+                ],
+                [
+                    'label' => 'Los Angeles',
+                    'value' => '2',
+                ],
+            ],
+        ]);
+        
+        $value = (new FakeSupportingClass)->exposedResolveCustomAttributeValue($type, 'Unknown');
+
+        $this->assertEquals('Unknown', $value);
+    }
+}
+
+class FakeSupportingClass 
+{
+    use HasCustomAttributes;
+
+    public function exposedResolveCustomAttributeType($attributeCode)
+    {
+        return $this->resolveCustomAttributeType($attributeCode);
+    }
+
+    public function exposedResolveCustomAttributeValue($type, $value)
+    {
+        return $this->resolveCustomAttributeValue($type, $value);
+    }
+}

--- a/tests/Support/HasCustomAttributesTest.php
+++ b/tests/Support/HasCustomAttributesTest.php
@@ -2,11 +2,11 @@
 
 namespace Grayloon\Magento\Tests\Support;
 
-use Grayloon\Magento\Tests\TestCase;
-use Illuminate\Support\Facades\Queue;
-use Grayloon\Magento\Support\HasCustomAttributes;
 use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
 use Grayloon\Magento\Models\MagentoCustomAttributeType;
+use Grayloon\Magento\Support\HasCustomAttributes;
+use Grayloon\Magento\Tests\TestCase;
+use Illuminate\Support\Facades\Queue;
 
 class HasCustomAttributesTest extends TestCase
 {
@@ -93,7 +93,7 @@ class HasCustomAttributesTest extends TestCase
     }
 }
 
-class FakeSupportingClass 
+class FakeSupportingClass
 {
     use HasCustomAttributes;
 

--- a/tests/Support/MagentoCategoriesTest.php
+++ b/tests/Support/MagentoCategoriesTest.php
@@ -3,14 +3,14 @@
 namespace Grayloon\Magento\Tests\Support;
 
 use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
-use Grayloon\Magento\Tests\TestCase;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Queue;
 use Grayloon\Magento\Models\MagentoCategory;
-use Grayloon\Magento\Support\MagentoCategories;
 use Grayloon\Magento\Models\MagentoCustomAttributeType;
-
+use Grayloon\Magento\Support\MagentoCategories;
+use Grayloon\Magento\Tests\TestCase;
 use function GuzzleHttp\Promise\queue;
+use Illuminate\Support\Facades\Http;
+
+use Illuminate\Support\Facades\Queue;
 
 class MagentoCategoriesTest extends TestCase
 {

--- a/tests/Support/MagentoCategoriesTest.php
+++ b/tests/Support/MagentoCategoriesTest.php
@@ -2,11 +2,15 @@
 
 namespace Grayloon\Magento\Tests\Support;
 
-use Grayloon\Magento\Models\MagentoCategory;
-use Grayloon\Magento\Models\MagentoCustomAttributeType;
-use Grayloon\Magento\Support\MagentoCategories;
+use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
 use Grayloon\Magento\Tests\TestCase;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Grayloon\Magento\Models\MagentoCategory;
+use Grayloon\Magento\Support\MagentoCategories;
+use Grayloon\Magento\Models\MagentoCustomAttributeType;
+
+use function GuzzleHttp\Promise\queue;
 
 class MagentoCategoriesTest extends TestCase
 {
@@ -27,6 +31,8 @@ class MagentoCategoriesTest extends TestCase
 
     public function test_can_create_magento_category()
     {
+        Queue::fake();
+        
         $categories = [
             [
                 'id'         => '1',
@@ -73,6 +79,7 @@ class MagentoCategoriesTest extends TestCase
         $this->assertEquals('path', $category->customAttributes()->first()->attribute_type);
         $this->assertEquals('1', $category->customAttributes()->first()->value);
         $this->assertEquals('foo/bar', $category->slug);
+        Queue::assertNothingPushed();
     }
 
     public function test_root_category_has_nullable_slug()
@@ -117,21 +124,7 @@ class MagentoCategoriesTest extends TestCase
 
     public function test_can_apply_new_custom_attribute_type_to_category()
     {
-        Http::fake(function ($request) {
-            return Http::response([
-                'options' => [
-                    [
-                        'label' => 'New York',
-                        'value' => '1',
-                    ],
-                    [
-                        'label' => 'Los Angeles',
-                        'value' => '2',
-                    ],
-                ],
-                'default_frontend_label' => 'Warehouse',
-            ], 200);
-        });
+        Queue::fake();
 
         factory(MagentoCustomAttributeType::class)->create(['name' => 'path']);
         factory(MagentoCustomAttributeType::class)->create(['name' => 'children_count']);
@@ -172,26 +165,13 @@ class MagentoCategoriesTest extends TestCase
         $category = MagentoCategory::first();
 
         $this->assertEquals(3, $category->customAttributes()->count());
-        $this->assertEquals('New York', $category->customAttributes()->where('attribute_type', 'warehouse_id')->first()->value);
+        $this->assertEquals('1', $category->customAttributes()->where('attribute_type', 'warehouse_id')->first()->value);
+        Queue::assertPushed(UpdateProductAttributeGroup::class);
     }
 
     public function test_can_apply_raw_value_attribute_if_unknown_type_option_in_category()
     {
-        Http::fake(function ($request) {
-            return Http::response([
-                'options' => [
-                    [
-                        'label' => 'New York',
-                        'value' => '1',
-                    ],
-                    [
-                        'label' => 'Los Angeles',
-                        'value' => '2',
-                    ],
-                ],
-                'default_frontend_label' => 'Warehouse',
-            ], 200);
-        });
+        Queue::fake();
 
         factory(MagentoCustomAttributeType::class)->create(['name' => 'path']);
         factory(MagentoCustomAttributeType::class)->create(['name' => 'children_count']);
@@ -233,5 +213,6 @@ class MagentoCategoriesTest extends TestCase
 
         $this->assertEquals(3, $category->customAttributes()->count());
         $this->assertEquals('Unknown', $category->customAttributes()->where('attribute_type', 'warehouse_id')->first()->value);
+        Queue::assertPushed(UpdateProductAttributeGroup::class);
     }
 }

--- a/tests/Support/MagentoCustomersTest.php
+++ b/tests/Support/MagentoCustomersTest.php
@@ -2,11 +2,13 @@
 
 namespace Grayloon\Magento\Tests\Support;
 
-use Grayloon\Magento\Models\MagentoCustomAttributeType;
-use Grayloon\Magento\Models\MagentoCustomer;
-use Grayloon\Magento\Support\MagentoCustomers;
+use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
 use Grayloon\Magento\Tests\TestCase;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Grayloon\Magento\Models\MagentoCustomer;
+use Grayloon\Magento\Support\MagentoCustomers;
+use Grayloon\Magento\Models\MagentoCustomAttributeType;
 
 class MagentoCustomersTest extends TestCase
 {
@@ -85,21 +87,7 @@ class MagentoCustomersTest extends TestCase
 
     public function test_can_apply_new_custom_attribute_type_to_customer()
     {
-        Http::fake(function ($request) {
-            return Http::response([
-                'options' => [
-                    [
-                        'label' => 'Yes',
-                        'value' => '1',
-                    ],
-                    [
-                        'label' => 'No',
-                        'value' => '0',
-                    ],
-                ],
-                'default_frontend_label' => 'Rewards Member',
-            ], 200);
-        });
+        Queue::fake();
 
         $customers = [
             [
@@ -151,5 +139,6 @@ class MagentoCustomersTest extends TestCase
         $this->assertEquals('rewards_member', $customer->customAttributes()->first()->attribute_type);
         $this->assertInstanceOf(MagentoCustomAttributeType::class, $customer->customAttributes()->first()->type()->first());
         $this->assertEquals('Rewards Member', $customer->customAttributes()->first()->type()->first()->display_name);
+        Queue::assertPushed(UpdateProductAttributeGroup::class);
     }
 }

--- a/tests/Support/MagentoCustomersTest.php
+++ b/tests/Support/MagentoCustomersTest.php
@@ -3,12 +3,12 @@
 namespace Grayloon\Magento\Tests\Support;
 
 use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
+use Grayloon\Magento\Models\MagentoCustomAttributeType;
+use Grayloon\Magento\Models\MagentoCustomer;
+use Grayloon\Magento\Support\MagentoCustomers;
 use Grayloon\Magento\Tests\TestCase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
-use Grayloon\Magento\Models\MagentoCustomer;
-use Grayloon\Magento\Support\MagentoCustomers;
-use Grayloon\Magento\Models\MagentoCustomAttributeType;
 
 class MagentoCustomersTest extends TestCase
 {

--- a/tests/Support/MagentoProductsTest.php
+++ b/tests/Support/MagentoProductsTest.php
@@ -3,6 +3,7 @@
 namespace Grayloon\Magento\Tests\Support;
 
 use Grayloon\Magento\Jobs\DownloadMagentoProductImage;
+use Grayloon\Magento\Jobs\UpdateProductAttributeGroup;
 use Grayloon\Magento\Models\MagentoCategory;
 use Grayloon\Magento\Models\MagentoCustomAttribute;
 use Grayloon\Magento\Models\MagentoCustomAttributeType;
@@ -31,21 +32,7 @@ class MagentoProductsTest extends TestCase
 
     public function test_magento_product_adds_attribute_type()
     {
-        Http::fake(function ($request) {
-            return Http::response([
-                'options' => [
-                    [
-                        'label' => 'New York',
-                        'value' => '1',
-                    ],
-                    [
-                        'label' => 'Los Angeles',
-                        'value' => '2',
-                    ],
-                ],
-                'default_frontend_label' => 'Warehouse',
-            ], 200);
-        });
+        Queue::fake();
 
         factory(MagentoCategory::class)->create();
 
@@ -81,29 +68,17 @@ class MagentoProductsTest extends TestCase
 
         $this->assertNotEmpty($product->customAttributes->first());
         $this->assertInstanceOf(MagentoCustomAttribute::class, $product->customAttributes->first());
-        $this->assertEquals('New York', $product->customAttributes->first()->value);
+        $this->assertEquals('1', $product->customAttributes->first()->value);
         $this->assertInstanceOf(MagentoCustomAttributeType::class, $product->customAttributes->first()->type()->first());
-        $this->assertEquals('Warehouse', $product->customAttributes->first()->type()->first()->display_name);
+        $this->assertEquals('Warehouse Id', $product->customAttributes->first()->type()->first()->display_name);
         $this->assertEquals('warehouse_id', $product->customAttributes->first()->type()->first()->name);
+        Queue::assertPushed(UpdateProductAttributeGroup::class);
+        Queue::assertPushed(UpdateProductAttributeGroup::class, fn ($job) => $job->type->id === $product->customAttributes->first()->type()->first()->id);
     }
 
     public function test_magento_product_unknown_attribute_type_value_resolves_as_raw_value()
     {
-        Http::fake(function ($request) {
-            return Http::response([
-                'options' => [
-                    [
-                        'label' => 'New York',
-                        'value' => '1',
-                    ],
-                    [
-                        'label' => 'Los Angeles',
-                        'value' => '2',
-                    ],
-                ],
-                'default_frontend_label' => 'Warehouse',
-            ], 200);
-        });
+        Queue::fake();
 
         factory(MagentoCategory::class)->create();
 
@@ -142,12 +117,58 @@ class MagentoProductsTest extends TestCase
         $this->assertEquals('Unknown', $product->customAttributes->first()->value);
     }
 
-    public function test_magento_product_existing_attribute_uses_existing_values()
+    public function test_magento_product_existing_attribute_type_doesnt_launch_api_job()
     {
-        factory(MagentoCategory::class)->create();
-        $type = factory(MagentoCustomAttributeType::class)->create([
+        Queue::fake();
+
+        factory(MagentoCustomAttributeType::class)->create([
             'name' => 'warehouse_id',
-            'display_name' => 'Warehouse',
+        ]);
+        factory(MagentoCategory::class)->create();
+
+        $products = [
+            [
+                'id'         => '1',
+                'name'       => 'Dunder Mifflin Paper',
+                'sku'        => 'DFPC001',
+                'price'      => 19.99,
+                'status'     => '1',
+                'visibility' => '1',
+                'type_id'    => 'simple',
+                'created_at' => now(),
+                'updated_at' => now(),
+                'weight'     => 10.00,
+                'extension_attributes' => [
+                    'website_id' => [1],
+                ],
+                'custom_attributes' => [
+                    [
+                        'attribute_code' => 'warehouse_id',
+                        'value'          => '1',
+                    ],
+                ],
+            ],
+        ];
+
+        $magentoProducts = new MagentoProducts();
+
+        $magentoProducts->updateProducts($products);
+
+        $product = MagentoProduct::with('customAttributes')->first();
+
+        $this->assertNotEmpty($product->customAttributes->first());
+        $this->assertInstanceOf(MagentoCustomAttribute::class, $product->customAttributes->first());
+        $this->assertEquals(1, $product->customAttributes->count());
+        $this->assertEquals(1, $product->customAttributes->first()->value);
+        Queue::assertNothingPushed();
+    }
+
+    public function test_magento_product_resolves_existing_value_from_api()
+    {
+        Queue::fake();
+
+        factory(MagentoCustomAttributeType::class)->create([
+            'name' => 'warehouse_id',
             'options' => [
                 [
                     'label' => 'New York',
@@ -156,9 +177,10 @@ class MagentoProductsTest extends TestCase
                 [
                     'label' => 'Los Angeles',
                     'value' => '2',
-                ],
-            ],
+                ]
+            ]
         ]);
+        factory(MagentoCategory::class)->create();
 
         $products = [
             [
@@ -194,6 +216,7 @@ class MagentoProductsTest extends TestCase
         $this->assertInstanceOf(MagentoCustomAttribute::class, $product->customAttributes->first());
         $this->assertEquals(1, $product->customAttributes->count());
         $this->assertEquals('New York', $product->customAttributes->first()->value);
+        Queue::assertNothingPushed();
     }
 
     public function test_magento_product_adds_associated_category()


### PR DESCRIPTION
PR launches jobs to retrieve Product Attribute information rather than immediately when the product attribute information isn't available.

Ref: #14 