### PR TITLE
Exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ MAGENTO_STORE_CODE="all"
 MAGENTO_API_VERSION="V1"
 ```
 
-> You can test your connection by running tinker, then: `(new \Grayloon\Magento\Magento)->api('schema')->show();`
 ## API Usage
 
 Example:
@@ -69,11 +68,9 @@ $response->body() : string;
 $response->json() : array|mixed;
 $response->status() : int;
 $response->ok() : bool;
-$response->successful() : bool;
-$response->failed() : bool;
-$response->serverError() : bool;
-$response->clientError() : bool;
 ```
+
+> Will throw an exception on >500 errors.
 
 ## Available Methods:
 

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -56,8 +56,8 @@ abstract class AbstractApi
      */
     protected function get($path, $parameters = [])
     {
-        return Http::withToken($this->magento->token)
-            ->get($this->apiRequest.$path, $parameters);
+        return $this->checkExceptions(Http::withToken($this->magento->token)
+            ->get($this->apiRequest.$path, $parameters));
     }
 
     /**
@@ -70,8 +70,24 @@ abstract class AbstractApi
      */
     protected function post($path, $parameters = [])
     {
-        return Http::withToken($this->magento->token)
-            ->post($this->apiRequest.$path, $parameters);
+        return $this->checkExceptions(Http::withToken($this->magento->token)
+            ->post($this->apiRequest.$path, $parameters));
+    }
+
+    /**
+     * Check for any type of invalid API Responses.
+     *
+     * @param \Illuminate\Http\Client\Response $response
+     * @throws \Exception
+     * @return void
+     */
+    protected function checkExceptions($response)
+    {
+        if (! $response->ok()) {
+            throw new Exception($response);
+        }
+
+        return $response;
     }
 
     /**

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -83,7 +83,7 @@ abstract class AbstractApi
      */
     protected function checkExceptions($response)
     {
-        if (! $response->ok()) {
+        if ($response->serverError()) {
             throw new Exception($response);
         }
 

--- a/tests/Api/AbstractApiTest.php
+++ b/tests/Api/AbstractApiTest.php
@@ -4,6 +4,7 @@ namespace Grayloon\Magento\Tests;
 
 use Grayloon\Magento\Api\AbstractApi;
 use Grayloon\Magento\Magento;
+use Illuminate\Support\Facades\Http;
 
 class AbstractApiTest extends TestCase
 {
@@ -20,9 +21,33 @@ class AbstractApiTest extends TestCase
 
         $this->assertEquals('example.com/rest/all/V1', $api->apiRequest);
     }
+
+    public function test_expect_throw_exception_on_get_api_error()
+    {
+        $this->expectException('exception');
+        Http::fake(['message' => 'There was an error.'], 500);
+        
+        (new FakeApiClass((new Magento('example.com'))))->fakeGetEndpoint();
+    }
+
+    public function test_expect_throw_exception_on_post_api_error()
+    {
+        $this->expectException('exception');
+        Http::fake(['message' => 'There was an error.'], 500);
+        
+        (new FakeApiClass((new Magento('example.com'))))->fakePostEndpoint();
+    }
 }
 
 class FakeApiClass extends AbstractApi
 {
-    //
+    public function fakeGetEndpoint()
+    {
+        $this->get('/foo');
+    }
+
+    public function fakePostEndpoint()
+    {
+        $this->post('/bar');
+    }
 }

--- a/tests/Api/AbstractApiTest.php
+++ b/tests/Api/AbstractApiTest.php
@@ -30,7 +30,7 @@ class AbstractApiTest extends TestCase
                 'message' => 'There was an error.',
             ], 500),
         ]);
-        
+
         (new FakeApiClass((new Magento('example.com'))))->fakeGetEndpoint();
     }
 
@@ -42,7 +42,7 @@ class AbstractApiTest extends TestCase
                 'message' => 'There was an error.',
             ], 500),
         ]);
-        
+
         (new FakeApiClass((new Magento('example.com'))))->fakePostEndpoint();
     }
 
@@ -53,7 +53,7 @@ class AbstractApiTest extends TestCase
                 'message' => 'Unauthorized',
             ], 401),
         ]);
-        
+
         $this->assertNull((new FakeApiClass((new Magento('foo.com'))))->fakeGetEndpoint());
     }
 
@@ -64,7 +64,7 @@ class AbstractApiTest extends TestCase
                 'message' => 'Ready to Rock!',
             ], 200),
         ]);
-        
+
         $this->assertNull((new FakeApiClass((new Magento('foo.com'))))->fakeGetEndpoint());
     }
 }

--- a/tests/Api/AbstractApiTest.php
+++ b/tests/Api/AbstractApiTest.php
@@ -25,7 +25,11 @@ class AbstractApiTest extends TestCase
     public function test_expect_throw_exception_on_get_api_error()
     {
         $this->expectException('exception');
-        Http::fake(['message' => 'There was an error.'], 500);
+        Http::fake([
+            '*' => Http::response([
+                'message' => 'There was an error.',
+            ], 500),
+        ]);
         
         (new FakeApiClass((new Magento('example.com'))))->fakeGetEndpoint();
     }
@@ -33,9 +37,35 @@ class AbstractApiTest extends TestCase
     public function test_expect_throw_exception_on_post_api_error()
     {
         $this->expectException('exception');
-        Http::fake(['message' => 'There was an error.'], 500);
+        Http::fake([
+            '*' => Http::response([
+                'message' => 'There was an error.',
+            ], 500),
+        ]);
         
         (new FakeApiClass((new Magento('example.com'))))->fakePostEndpoint();
+    }
+
+    public function test_400_error_does_not_throw_exception()
+    {
+        Http::fake([
+            '*' => Http::response([
+                'message' => 'Unauthorized',
+            ], 401),
+        ]);
+        
+        $this->assertNull((new FakeApiClass((new Magento('foo.com'))))->fakeGetEndpoint());
+    }
+
+    public function test_200_error_does_not_throw_exception()
+    {
+        Http::fake([
+            '*' => Http::response([
+                'message' => 'Ready to Rock!',
+            ], 200),
+        ]);
+        
+        $this->assertNull((new FakeApiClass((new Magento('foo.com'))))->fakeGetEndpoint());
     }
 }
 


### PR DESCRIPTION
With this PR, server errors from Magento will now be fired as exceptions to prevent false positive responses.