### PR TITLE
Feature: Add custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A Magento 2 API Object Oriented wrapper for a Laravel application.
   - [Products](#products)
   - [Schema](#schema)
   - [Source Items](#source-items)
+  - [Custom modules](#custom modules)
 
 
 ## Installation
@@ -221,6 +222,25 @@ $magento->api('products')->all($pageSize = 50, $currentPage = 1, $filters = []);
 Get info about a product by the product SKU:
 ```php
 $magento->api('products')->show($sku);
+```
+
+### Custom modules
+Magento modules can have their own API endpoints.
+For example:
+```xml
+<route method="POST" url="/V1/custom/save">
+    ...
+</route>
+<route method="GET" url="/V1/custom/get/:id">
+    ...
+</route>
+```
+To use these you can directly use get/post methods:
+```php
+$magento->api('custom')->post('save', [...]);
+```
+```php
+$magento->api('custom')->get('get/1');
 ```
 
 <a id="schema"></a>

--- a/README.md
+++ b/README.md
@@ -228,19 +228,19 @@ $magento->api('products')->show($sku);
 Magento modules can have their own API endpoints.
 For example:
 ```xml
-<route method="POST" url="/V1/custom/save">
+<route method="POST" url="/V1/my-custom-endpoint/save">
     ...
 </route>
-<route method="GET" url="/V1/custom/get/:id">
+<route method="GET" url="/V1/my-custom-endpoint/get/:id">
     ...
 </route>
 ```
 To use these you can directly use get/post methods:
 ```php
-$magento->api('custom')->post('save', [...]);
+$magento->api('my-custom-endpoint')->post('save', [...]);
 ```
 ```php
-$magento->api('custom')->get('get/1');
+$magento->api('my-custom-endpoint')->get('get/1');
 ```
 
 <a id="schema"></a>

--- a/src/Api/Custom.php
+++ b/src/Api/Custom.php
@@ -13,7 +13,7 @@ class Custom extends AbstractApi
 
     /**
      * Custom constructor.
-     * 
+     *
      * @param string $endpoint
      */
     public function __construct(string $endpoint, Magento $magento)
@@ -26,14 +26,14 @@ class Custom extends AbstractApi
     /**
      * Dynamic call to passthrough.
      *
-     * @param  string $method
-     * @param  array  $args
+     * @param string $method
+     * @param array $args
      * @return mixed
      */
     public function __call($method, $args)
     {
         if ($method == 'get' || $method == 'post') {
-            $args[0] = rtrim($this->endpoint, '/') . '/' . $args[0];
+            $args[0] = rtrim($this->endpoint, '/').'/'.$args[0];
         }
 
         return call_user_func_array([$this, $method], $args);

--- a/src/Api/Custom.php
+++ b/src/Api/Custom.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Grayloon\Magento\Api;
+
+use Grayloon\Magento\Magento;
+
+class Custom extends AbstractApi
+{
+    /**
+     * @var string Magento API endpoint
+     */
+    protected $endpoint;
+
+    /**
+     * Custom constructor.
+     * 
+     * @param string $endpoint
+     */
+    public function __construct(string $endpoint, Magento $magento)
+    {
+        $this->endpoint = $endpoint;
+
+        parent::__construct($magento);
+    }
+
+    /**
+     * Dynamic call to passthrough.
+     *
+     * @param  string $method
+     * @param  array  $args
+     * @return mixed
+     */
+    public function __call($method, $args)
+    {
+        if ($method == 'get' || $method == 'post') {
+            $args[0] = rtrim($this->endpoint, '/') . '/' . $args[0];
+        }
+
+        return call_user_func_array([$this, $method], $args);
+    }
+}

--- a/src/Magento.php
+++ b/src/Magento.php
@@ -2,6 +2,7 @@
 
 namespace Grayloon\Magento;
 
+use Grayloon\Magento\Api\Custom;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -49,6 +50,12 @@ class Magento
      */
     public $storeCode;
 
+    /**
+     * Magento constructor.
+     *
+     * @param string $baseUrl
+     * @param string $token
+     */
     public function __construct($baseUrl = null, $token = null)
     {
         $this->baseUrl = $baseUrl ?: config('magento.base_url');
@@ -68,12 +75,13 @@ class Magento
      */
     public function api($name)
     {
-        $apiMethodExists = class_exists($name = "\Grayloon\Magento\Api\\".Str::ucfirst($name));
+        $className = $name;
+        $apiMethodExists = class_exists($className = "\Grayloon\Magento\Api\\".Str::ucfirst($className));
 
         if (! $apiMethodExists) {
-            throw new InvalidArgumentException(sprintf('Undefined api instance called: "%s"', $name));
+            return new Custom($name, $this);
         }
 
-        return new $name($this);
+        return new $className($this);
     }
 }

--- a/tests/Api/CustomTest.php
+++ b/tests/Api/CustomTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Grayloon\Magento\Tests;
+
+use Grayloon\Magento\Magento;
+use Illuminate\Support\Facades\Http;
+
+class CustomTest extends TestCase
+{
+    public function test_can_get_custom_endpoint()
+    {
+        Http::fake([
+            '*rest/all/V1/foo/bar' => Http::response([], 200),
+        ]);
+
+        $magento = new Magento();
+        $customApi = $magento->api('/foo')->get('bar');
+
+        $this->assertTrue($customApi->ok());
+    }
+
+    public function test_can_post_custom_endpoint()
+    {
+        Http::fake([
+            '*rest/all/V1/foo/bar' => Http::response([], 200),
+        ]);
+
+        $magento = new Magento();
+        $customApi = $magento->api('/foo')->post('bar');
+
+        $this->assertTrue($customApi->ok());
+    }
+
+    public function test_custom_post_endpoint_passes_params()
+    {
+        Http::fake([
+            '*rest/all/V1/foo/bar' => Http::response([], 200, ['baz' => 'test']),
+        ]);
+
+        $magento = new Magento();
+        $customApi = $magento->api('/foo')->post('bar', [
+            'baz' => 'test',
+        ]);
+
+        $this->assertTrue($customApi->ok());
+    }
+}


### PR DESCRIPTION
Magento 2 modules can have their own api endpoints. This PR makes it possible to use those.
For example:
`$magento = new Magento();

$response = $magento->api('/suttonsilver-pricelists')->get('pricelist/12');`