### PR TITLE
Ability to use singular custom endpoints

### DIFF
--- a/src/Api/Custom.php
+++ b/src/Api/Custom.php
@@ -35,7 +35,9 @@ class Custom extends AbstractApi
     public function __call($method, $args)
     {
         if (in_array($method, self::HTTP_METHODS)) {
-            $args[0] = $this->endpoint.ltrim($args[0], '/');
+            $args[0] = (isset($args[0]))
+                ? $this->endpoint.ltrim($args[0], '/')
+                : rtrim($this->endpoint, '/');
         }
 
         return call_user_func_array([$this, $method], $args);

--- a/tests/Api/CustomTest.php
+++ b/tests/Api/CustomTest.php
@@ -18,6 +18,17 @@ class CustomTest extends TestCase
         $this->assertTrue($customApi->ok());
     }
 
+    public function test_can_get_singular_custom_endpoint()
+    {
+        Http::fake([
+            '*rest/all/V1/foo' => Http::response([], 200),
+        ]);
+
+        $customApi = MagentoFacade::api('foo')->get();
+
+        $this->assertTrue($customApi->ok());
+    }
+
     public function test_can_post_custom_endpoint()
     {
         Http::fake([


### PR DESCRIPTION
PR allows for singular custom endpoints.

Currently, you can use custom endpoints:

`rest/all/V1/foo/bar`
```php
$magento->api('foo')->get('bar');
```

But we are unable to use custom singular API endpoints:
`rest/all/V1/foo`
```php
$magento->api('foo')->get();
```


