### PR TITLE
fix Product filters

### DIFF
--- a/src/Api/Products.php
+++ b/src/Api/Products.php
@@ -12,12 +12,12 @@ class Products extends AbstractApi
      *
      * @return  array
      */
-    public function all($pageSize = 50, $currentPage = 1)
+    public function all($pageSize = 50, $currentPage = 1, $filters = [])
     {
-        return $this->get('/products', [
+        return $this->get('/products', array_merge($filters, [
             'searchCriteria[pageSize]'    => $pageSize,
             'searchCriteria[currentPage]' => $currentPage,
-        ]);
+        ]));
     }
 
     /**


### PR DESCRIPTION
we tried to add additional filters but they are ignored in Products api,

```php
$magento = new Magento();

$response = $magento->api('products')->all($pageSize = 2, $currentPage = 1, [
    'searchCriteria[filterGroups][0][filters][0][field]' => 'status',
    'searchCriteria[filterGroups][0][filters][0][value]' => '2'
]);
```

it does work by merging array with default filters

