### PR TITLE
Customer Group Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Magento 2 API Object Oriented wrapper for a Laravel application.
   - [Categories](#categories)
   - [Customer Token](#customer-token)
   - [Customers](#customers)
+  - [Customer Groups](#customer-groups)
   - [Guest Cart](#guest-cart)
   - [Orders](#orders)
   - [Product Attributes](#product-attributes)
@@ -210,6 +211,59 @@ Magento::api('customers')->password($email, $template, $websiteId);
 Reset customer password.
 ```php
 Magento::api('customers')->resetPassword($email, $resetToken, $newPassword);
+```
+
+<a id="customer-groups"></a>
+
+### Customer Groups
+
+GET `/V1/customerGroups/{id}`
+
+Show the customer group by the provided ID.
+```php
+Magento::api('customerGroups')->show($id);
+```
+
+PUT `/V1/customerGroups/{id}`
+
+Save the customer group by the provided ID.
+```php
+Magento::api('customerGroups')->saveGroup($id, $customerGroupRepositoryV1SavePutBody = []);
+```
+
+DELETE `/V1/customerGroups/{id}`
+
+Delete customer group by the provided ID.
+```php
+Magento::api('customerGroups')->deleteGroup($id);
+```
+
+POST `/V1/customerGroups`
+
+Save/Create Customer Group.
+```php
+Magento::api('customerGroups')->createGroup($customerGroupRepositoryV1SavePostBody = []);
+```
+
+GET `/V1/customerGroups/search`
+
+Search the Customer Groups.
+```php
+Magento::api('customerGroups')->search($pageSize = 50, $currentPage = 1, $filters = []);
+```
+
+GET `/V1/customerGroups/default`
+
+Get the default customer group.
+```php
+Magento::api('customerGroups')->default();
+```
+
+PUT `/V1/customerGroups/default/{id}`
+
+Set the default customer group.
+```php
+Magento::api('customerGroups')->setDefault($id);
 ```
 
 <a id="guest-cart"></a>

--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ Set the default customer group.
 Magento::api('customerGroups')->setDefault($id);
 ```
 
+GET `/V1/customerGroups/{id}/permissions`
+
+Determine if customer group can be deleted.
+```php
+Magento::api('customerGroups')->permissions($id);
+```
+
+
 <a id="guest-cart"></a>
 ### Guest Cart (various)
 

--- a/src/Api/CustomerGroups.php
+++ b/src/Api/CustomerGroups.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Grayloon\Magento\Api;
+
+class CustomerGroups extends AbstractApi
+{
+    /**
+     * Show the customer group by the provided ID.
+     *
+     * @param  int  $id
+     * @return array
+     */
+    public function show($id)
+    {
+        return $this->get('/customerGroups/' . $id);
+    }
+
+    /**
+     * Save the customer group by the provided ID.
+     *
+     * @param  int  $id
+     * @param  array  $customerGroupRepositoryV1SavePutBody
+     * @return array
+     */
+    public function saveGroup($id, $customerGroupRepositoryV1SavePutBody = [])
+    {
+        return $this->put('/customerGroups/' . $id, $customerGroupRepositoryV1SavePutBody);
+    }
+
+    /**
+     * Delete customer group by the provided ID.
+     *
+     * @param  int  $id
+     * @return array
+     */
+    public function deleteGroup($id)
+    {
+        return $this->delete('/customerGroups/' . $id);
+    }
+
+    /**
+     * Save/Create Customer Group
+     *
+     * @param  array  $customerGroupRepositoryV1SavePutBody
+     * @return array
+     */
+    public function createGroup($customerGroupRepositoryV1SavePostBody = [])
+    {
+        return $this->post('/customerGroups', $customerGroupRepositoryV1SavePostBody);
+    }
+
+    /**
+     * The list of Customer Groups.
+     *
+     * @param  int  $pageSize
+     * @param  int  $currentPage
+     * @param  array  $filters
+     *
+     * @return array
+     */
+    public function search($pageSize = 50, $currentPage = 1, $filters = [])
+    {
+        return $this->get('/customerGroups/search', array_merge($filters, [
+            'searchCriteria[pageSize]'    => $pageSize,
+            'searchCriteria[currentPage]' => $currentPage,
+        ]));
+    }
+
+    /**
+     * Get the default Customer Group.
+     *
+     * @return array
+     */
+    public function default()
+    {
+        return $this->get('/customerGroups/default');
+    }
+
+    /**
+     * Set the system default customer group.
+     *
+     * @param  int  $id
+     * @return array
+     */
+    public function setDefault($id)
+    {
+        return $this->put('/customerGroups/default/' . $id);
+    }
+
+
+    /**
+     * Check if customer group can be deleted.
+     *
+     * @param  int  $id
+     * @return array|bool
+     */
+    public function permissions($id)
+    {
+        return $this->get('/customerGroups/' . $id . '/permissions');
+    }
+}

--- a/src/Api/CustomerGroups.php
+++ b/src/Api/CustomerGroups.php
@@ -12,7 +12,7 @@ class CustomerGroups extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('/customerGroups/' . $id);
+        return $this->get('/customerGroups/'.$id);
     }
 
     /**
@@ -24,7 +24,7 @@ class CustomerGroups extends AbstractApi
      */
     public function saveGroup($id, $customerGroupRepositoryV1SavePutBody = [])
     {
-        return $this->put('/customerGroups/' . $id, $customerGroupRepositoryV1SavePutBody);
+        return $this->put('/customerGroups/'.$id, $customerGroupRepositoryV1SavePutBody);
     }
 
     /**
@@ -35,11 +35,11 @@ class CustomerGroups extends AbstractApi
      */
     public function deleteGroup($id)
     {
-        return $this->delete('/customerGroups/' . $id);
+        return $this->delete('/customerGroups/'.$id);
     }
 
     /**
-     * Save/Create Customer Group
+     * Save/Create Customer Group.
      *
      * @param  array  $customerGroupRepositoryV1SavePutBody
      * @return array
@@ -84,9 +84,8 @@ class CustomerGroups extends AbstractApi
      */
     public function setDefault($id)
     {
-        return $this->put('/customerGroups/default/' . $id);
+        return $this->put('/customerGroups/default/'.$id);
     }
-
 
     /**
      * Check if customer group can be deleted.
@@ -96,6 +95,6 @@ class CustomerGroups extends AbstractApi
      */
     public function permissions($id)
     {
-        return $this->get('/customerGroups/' . $id . '/permissions');
+        return $this->get('/customerGroups/'.$id.'/permissions');
     }
 }

--- a/src/Api/CustomerGroups.php
+++ b/src/Api/CustomerGroups.php
@@ -50,7 +50,7 @@ class CustomerGroups extends AbstractApi
     }
 
     /**
-     * The list of Customer Groups.
+     * Search the Customer Groups.
      *
      * @param  int  $pageSize
      * @param  int  $currentPage

--- a/tests/Api/CustomerGroupsTest.php
+++ b/tests/Api/CustomerGroupsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Grayloon\Magento\Tests;
+
+use Grayloon\Magento\Api\CustomerGroups;
+use Grayloon\Magento\MagentoFacade;
+use Illuminate\Support\Facades\Http;
+
+class CustomerGroupsTest extends TestCase
+{
+    /** @test */
+    public function it_can_instanciate()
+    {
+        $this->assertInstanceOf(CustomerGroups::class, MagentoFacade::api('customerGroups'));
+    }
+
+    /** @test */
+    public function it_can_show()
+    {
+        Http::fake([
+            '*rest/all/V1/customerGroups/1' => Http::response([], 200),
+        ]);
+
+        $api = MagentoFacade::api('customerGroups')->show(1);
+
+        $this->assertTrue($api->ok());
+    }
+
+    /** @test */
+    public function it_can_save_group()
+    {
+        Http::fake([
+            '*rest/all/V1/customerGroups/1' => Http::response([], 200),
+        ]);
+
+        $api = MagentoFacade::api('customerGroups')->saveGroup(1, []);
+
+        $this->assertTrue($api->ok());
+    }
+
+    /** @test */
+    public function it_can_delete_group()
+    {
+        Http::fake([
+            '*rest/all/V1/customerGroups/1' => Http::response([], 200),
+        ]);
+
+        $api = MagentoFacade::api('customerGroups')->deleteGroup(1);
+
+        $this->assertTrue($api->ok());
+    }
+
+    /** @test */
+    public function it_can_create_group()
+    {
+        Http::fake([
+            '*rest/all/V1/customerGroups' => Http::response([], 200),
+        ]);
+
+        $api = MagentoFacade::api('customerGroups')->createGroup([]);
+
+        $this->assertTrue($api->ok());
+    }
+
+    /** @test */
+    public function it_can_search_groups()
+    {
+        Http::fake([
+            '*rest/all/V1/customerGroups/search*' => Http::response([], 200),
+        ]);
+
+        $api = MagentoFacade::api('customerGroups')->search();
+
+        $this->assertTrue($api->ok());
+    }
+
+    /** @test */
+    public function it_can_get_default()
+    {
+        Http::fake([
+            '*rest/all/V1/customerGroups/default' => Http::response([], 200),
+        ]);
+
+        $api = MagentoFacade::api('customerGroups')->default();
+
+        $this->assertTrue($api->ok());
+    }
+
+    /** @test */
+    public function it_can_set_default()
+    {
+        Http::fake([
+            '*rest/all/V1/customerGroups/default/1' => Http::response([], 200),
+        ]);
+
+        $api = MagentoFacade::api('customerGroups')->setDefault(1);
+
+        $this->assertTrue($api->ok());
+    }
+}


### PR DESCRIPTION
Adds Customer Group Endpoints:

- GET `/V1/customerGroups/{id}` - Show the customer group by the provided ID.
- PUT `/V1/customerGroups/{id}` - Save the customer group by the provided ID.
- DELETE `/V1/customerGroups/{id}` - Delete customer group by the provided ID.
- POST `/V1/customerGroups` - Save/Create Customer Group.
- GET `/V1/customerGroups/search` - Search the Customer Groups.
- GET `/V1/customerGroups/default` - Get the default customer group.
- PUT `/V1/customerGroups/default/{id}` - Set the default customer group.
- GET `/V1/customerGroups/{id}/permissions` - Determine if customer group can be deleted.